### PR TITLE
Fixed LaTeX display of matrix name in show_matrix_effect.

### DIFF
--- a/jhwutils/matrices.py
+++ b/jhwutils/matrices.py
@@ -145,7 +145,7 @@ def show_boxed_tensor_latex(x, box_rows=True):
 
 
 def show_matrix_effect(m, suptitle=""):
-    print_matrix("A_{\\text{%s}}"%suptitle, m)
+    print_matrix(suptitle, m)
     def piped(ax, pts):
         f = 1.08
         a, b, c, d = (pts[:, 0] * f, pts[:, 9] * f, pts[:, 90] * f,


### PR DESCRIPTION
Hi John,

I made a minor change to the display of the matrix name in show_matrix_effect. This should fix the issue in cell 13 (the cell that demonstrates matrix powers visually) in week_5_matrices_ii_clean.ipynb, where the matrix name A^i is displayed as A_(A^i).

Best wishes,

Carol
