### PR TITLE
Enable LaTeX titles in show_matrix_effect

### DIFF
--- a/jhwutils/matrices.py
+++ b/jhwutils/matrices.py
@@ -207,4 +207,4 @@ def show_matrix_effect(m, suptitle=""):
     rax.set_xlim(-1.5, 1.5)
     lax.set_ylim(-1.5, 1.5)
     rax.set_ylim(-1.5, 1.5)        
-    plt.suptitle(suptitle)
+    plt.suptitle(f"${suptitle}$" if suptitle != "" else "")


### PR DESCRIPTION
The current implementation printed LaTeX suptitles like "\Sigma" correctly for the print_matrix part but the plot-title was no LaTeX formula. The proposed change will improve that.